### PR TITLE
Fix typos in includes causing compilation errors

### DIFF
--- a/DCCInspector-EX.ino
+++ b/DCCInspector-EX.ino
@@ -145,7 +145,7 @@
 #include "StringBuilder.h"
 
 // Statistics structures and functions.
-#include "DccStatistics.h"
+#include "DCCStatistics.h"
 
 const int nPackets = 16;  // Number of packet buffers
 const int pktLength = 8;  // Max length+1 in bytes of DCC packet

--- a/DCCStatistics.h
+++ b/DCCStatistics.h
@@ -28,7 +28,7 @@
 #define dccstats_h
 
 #include <Arduino.h>
-#include "config.h"
+#include "Config.h"
 
 #if defined(ESP32) || defined(ESP8266) || defined(ESP_PLATFORM)
 #define INTERRUPT_SAFE IRAM_ATTR

--- a/EventTimer_AtMega.h
+++ b/EventTimer_AtMega.h
@@ -33,7 +33,7 @@
 #define eventtimer_default_h
 
 #include <Arduino.h>
-#include "config.h"
+#include "Config.h"
 
 #define GPIO_PREFER_SPEED
 #include <DIO2.h>


### PR DESCRIPTION
When I tried uploading on Ubuntu I couldn't as the file config.h could not be found.
Changing the include lines to have the correct case fixed the issue.